### PR TITLE
Adding packages.json so this repo can be used with create-project

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,0 +1,16 @@
+{
+  "packages": {
+    "fruition-github": {
+      "dev-master": {
+        "name": "fruition/wingsuit-kickstarter",
+        "source": {
+          "reference": "dev-master",
+          "type": "github",
+          "url": "https://github.com/fruition/wingsuit-kickstarter"
+        },
+        "type": "project",
+        "version": "dev-master"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is being added so that this repository can be used to test composer create-project with the --repositories flag.

Note:  This will need to be removed before creating a MR against the parent repository from which this one was forked.